### PR TITLE
Switch from AccessToolsFacade to Mod

### DIFF
--- a/SpriteMaster/Harmonize/Patches/Game/ClickCrash.cs
+++ b/SpriteMaster/Harmonize/Patches/Game/ClickCrash.cs
@@ -77,7 +77,7 @@ internal static class ClickCrash {
 	}
 
 	[Harmonize(
-		typeof(StardewModdingAPI.Framework.ModLoading.RewriteFacades.AccessToolsFacade),
+		typeof(StardewModdingAPI.Mod),
 		"StardewModdingAPI.Framework.SModHooks",
 		"StartTask",
 		Harmonize.Fixation.Prefix,
@@ -93,7 +93,7 @@ internal static class ClickCrash {
 	}
 
 	[Harmonize(
-		typeof(StardewModdingAPI.Framework.ModLoading.RewriteFacades.AccessToolsFacade),
+		typeof(StardewModdingAPI.Mod),
 		"StardewModdingAPI.Framework.SModHooks",
 		"StartTask",
 		Harmonize.Fixation.Postfix,

--- a/SpriteMaster/Harmonize/Patches/SMAPI/DeprecationManager.cs
+++ b/SpriteMaster/Harmonize/Patches/SMAPI/DeprecationManager.cs
@@ -7,7 +7,7 @@ internal static class DeprecationManager {
 	private static readonly object DeprecationManagerLock = new();
 
 	[Harmonize(
-		typeof(StardewModdingAPI.Framework.ModLoading.RewriteFacades.AccessToolsFacade),
+		typeof(StardewModdingAPI.Mod),
 		"StardewModdingAPI.Framework.Deprecations.DeprecationManager",
 		"Warn",
 		Harmonize.Fixation.Prefix,
@@ -27,7 +27,7 @@ internal static class DeprecationManager {
 	}
 
 	[Harmonize(
-		typeof(StardewModdingAPI.Framework.ModLoading.RewriteFacades.AccessToolsFacade),
+		typeof(StardewModdingAPI.Mod),
 		"StardewModdingAPI.Framework.Deprecations.DeprecationManager",
 		"Warn",
 		Harmonize.Fixation.Finalizer,
@@ -47,7 +47,7 @@ internal static class DeprecationManager {
 	}
 
 	[Harmonize(
-		typeof(StardewModdingAPI.Framework.ModLoading.RewriteFacades.AccessToolsFacade),
+		typeof(StardewModdingAPI.Mod),
 		"StardewModdingAPI.Framework.Deprecations.DeprecationManager",
 		"PrintQueued",
 		Harmonize.Fixation.Prefix,
@@ -59,7 +59,7 @@ internal static class DeprecationManager {
 	}
 
 	[Harmonize(
-		typeof(StardewModdingAPI.Framework.ModLoading.RewriteFacades.AccessToolsFacade),
+		typeof(StardewModdingAPI.Mod),
 		"StardewModdingAPI.Framework.Deprecations.DeprecationManager",
 		"PrintQueued",
 		Harmonize.Fixation.Finalizer,

--- a/SpriteMaster/Harmonize/Patches/SMAPI/LogMonitor.cs
+++ b/SpriteMaster/Harmonize/Patches/SMAPI/LogMonitor.cs
@@ -28,7 +28,7 @@ internal static class LogMonitor {
 	}
 
 	[Harmonize(
-		typeof(StardewModdingAPI.Framework.ModLoading.RewriteFacades.AccessToolsFacade),
+		typeof(StardewModdingAPI.Mod),
 		"StardewModdingAPI.Framework.Monitor",
 		"LogImpl",
 		Harmonize.Fixation.Prefix,
@@ -56,7 +56,7 @@ internal static class LogMonitor {
 	}
 
 	[Harmonize(
-		typeof(StardewModdingAPI.Framework.ModLoading.RewriteFacades.AccessToolsFacade),
+		typeof(StardewModdingAPI.Mod),
 		"StardewModdingAPI.Framework.Monitor",
 		"LogImpl",
 		Harmonize.Fixation.Finalizer,

--- a/SpriteMaster/Harmonize/Patches/SMAPI/PAssetDataForImage.cs
+++ b/SpriteMaster/Harmonize/Patches/SMAPI/PAssetDataForImage.cs
@@ -11,7 +11,7 @@ using System.Runtime.CompilerServices;
 namespace SpriteMaster.Harmonize.Patches.SMAPI;
 
 internal static class PAssetDataForImage {
-	private static readonly Assembly ReferenceAssembly = typeof(StardewModdingAPI.Framework.ModLoading.RewriteFacades.AccessToolsFacade).Assembly;
+	private static readonly Assembly ReferenceAssembly = typeof(StardewModdingAPI.Mod).Assembly;
 	private static readonly Type? AssetDataForImageType = ReferenceAssembly.
 		GetType("StardewModdingAPI.Framework.Content.AssetDataForImage");
 	private static readonly byte MinOpacity = (byte?)AssetDataForImageType?.
@@ -139,7 +139,7 @@ internal static class PAssetDataForImage {
 	}
 
 	[Harmonize(
-		typeof(StardewModdingAPI.Framework.ModLoading.RewriteFacades.AccessToolsFacade),
+		typeof(StardewModdingAPI.Mod),
 		"StardewModdingAPI.Framework.Content.AssetDataForImage",
 		"PatchImage",
 		Harmonize.Fixation.Prefix,
@@ -190,7 +190,7 @@ internal static class PAssetDataForImage {
 	}
 
 	[Harmonize(
-	typeof(StardewModdingAPI.Framework.ModLoading.RewriteFacades.AccessToolsFacade),
+	typeof(StardewModdingAPI.Mod),
 	"StardewModdingAPI.Framework.Content.AssetDataForImage",
 	"PatchImageImpl",
 	Harmonize.Fixation.Prefix,


### PR DESCRIPTION
This is due to the fact that the RewriteFacades had their namespace changed and switching to a more reliable class as all of these are only used for Assembly references
